### PR TITLE
Complete Go port with tests

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -16,6 +16,9 @@ func (c *Client) Query(ctx context.Context, prompt string, opts *model.Options) 
 	if sp, ok := c.Transport.(*SubprocessCLITransport); ok {
 		sp.Prompt = prompt
 		sp.Options = opts
+		if opts != nil {
+			sp.Cwd = opts.Cwd
+		}
 	}
 
 	if err := c.Transport.Connect(ctx); err != nil {

--- a/internal/client_test.go
+++ b/internal/client_test.go
@@ -1,0 +1,108 @@
+package internal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/anthropics/claude-code-sdk-go/model"
+)
+
+type stubTransport struct {
+	msgs         []map[string]any
+	connected    bool
+	disconnected bool
+}
+
+func (s *stubTransport) Connect(ctx context.Context) error {
+	s.connected = true
+	return nil
+}
+
+func (s *stubTransport) Disconnect() error {
+	s.disconnected = true
+	return nil
+}
+
+func (s *stubTransport) ReceiveMessages(ctx context.Context) (<-chan map[string]any, error) {
+	ch := make(chan map[string]any)
+	go func() {
+		for _, m := range s.msgs {
+			ch <- m
+		}
+		close(ch)
+	}()
+	return ch, nil
+}
+
+func TestParseMessageUser(t *testing.T) {
+	data := map[string]any{
+		"type": "user",
+		"message": map[string]any{
+			"content": "hi",
+		},
+	}
+	m := parseMessage(data)
+	u, ok := m.(model.UserMessage)
+	if !ok || u.Content != "hi" {
+		t.Fatalf("unexpected message: %#v", m)
+	}
+}
+
+func TestParseMessageAssistant(t *testing.T) {
+	data := map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"content": []any{
+				map[string]any{"type": "text", "text": "hello"},
+				map[string]any{"type": "tool_use", "id": "1", "name": "Read", "input": map[string]any{"file": "a.txt"}},
+			},
+		},
+	}
+	m := parseMessage(data)
+	a, ok := m.(model.AssistantMessage)
+	if !ok || len(a.Content) != 2 {
+		t.Fatalf("unexpected message: %#v", m)
+	}
+	if tb, ok := a.Content[0].(model.TextBlock); !ok || tb.Text != "hello" {
+		t.Fatalf("unexpected first block: %#v", a.Content[0])
+	}
+	if ub, ok := a.Content[1].(model.ToolUseBlock); !ok || ub.Name != "Read" {
+		t.Fatalf("unexpected second block: %#v", a.Content[1])
+	}
+}
+
+func TestParseMessageResult(t *testing.T) {
+	data := map[string]any{
+		"type":      "result",
+		"subtype":   "success",
+		"cost_usd":  0.1,
+		"num_turns": 1,
+	}
+	m := parseMessage(data)
+	r, ok := m.(model.ResultMessage)
+	if !ok || r.Subtype != "success" || r.CostUSD != 0.1 {
+		t.Fatalf("unexpected message: %#v", m)
+	}
+}
+
+func TestClientQuery(t *testing.T) {
+	st := &stubTransport{msgs: []map[string]any{
+		{"type": "user", "message": map[string]any{"content": "hi"}},
+		{"type": "result", "subtype": "done"},
+	}}
+	c := &Client{Transport: st}
+	ch, err := c.Query(context.Background(), "hi", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var msgs []model.Message
+	for m := range ch {
+		msgs = append(msgs, m)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+	if !st.connected || !st.disconnected {
+		t.Fatalf("transport lifecycle not called")
+	}
+}

--- a/model/errors_test.go
+++ b/model/errors_test.go
@@ -1,0 +1,20 @@
+package model
+
+import "testing"
+
+func TestProcessError(t *testing.T) {
+	err := &ProcessError{Msg: "fail", ExitCode: 1, Stderr: "bad"}
+	if err.Error() == "" {
+		t.Fatal("missing error message")
+	}
+	if err.ExitCode != 1 || err.Stderr != "bad" {
+		t.Fatal("fields not set")
+	}
+}
+
+func TestCLINotFoundError(t *testing.T) {
+	err := &CLINotFoundError{Msg: "missing"}
+	if err.Error() != "missing" {
+		t.Fatalf("unexpected message: %s", err.Error())
+	}
+}

--- a/model/types_test.go
+++ b/model/types_test.go
@@ -1,0 +1,27 @@
+package model
+
+import "testing"
+
+func TestUserMessage(t *testing.T) {
+	m := UserMessage{Content: "hi"}
+	if m.Content != "hi" {
+		t.Fatal("unexpected content")
+	}
+}
+
+func TestAssistantMessage(t *testing.T) {
+	msg := AssistantMessage{Content: []ContentBlock{TextBlock{Text: "hello"}}}
+	if len(msg.Content) != 1 {
+		t.Fatalf("expected 1 block")
+	}
+}
+
+func TestOptionsDefaults(t *testing.T) {
+	opts := Options{}
+	if opts.MaxThinkingTokens != 0 {
+		t.Fatalf("expected default 0, got %d", opts.MaxThinkingTokens)
+	}
+	if opts.PermissionMode != "" {
+		t.Fatalf("expected empty permission mode")
+	}
+}


### PR DESCRIPTION
## Summary
- wire options.cwd into client
- add unit tests for client parsing
- add model tests for types and error values

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68505dfd2fc0832796e4321811acee8e