### PR TITLE
Update port TODO with remaining parity tasks

### DIFF
--- a/PORT_TODO.md
+++ b/PORT_TODO.md
@@ -179,6 +179,19 @@ Set up automated testing and quality checks:
 - **Dependabot**: Enable automatic dependency updates. ✅
 - **Release Automation**: Consider using `goreleaser` for automated releases. ✅
 
+## Remaining Parity Tasks
+
+The bulk of the Python SDK functionality has been ported, but a few gaps remain
+to match the reference implementation:
+
+- Add a `SendRequest()` method to the `Transport` interface so that alternative
+  transports can conform to the same API as the Python SDK.
+- Expose an option for specifying a custom `CLIPath` when creating the
+  transport. The Python SDK allows overriding the path to the `claude` binary.
+- Include `MaxThinkingTokens` and `MCPTools` when building the CLI command and
+  use the Python default of `8000` thinking tokens when unspecified.
+
+
 ## 11. Future Enhancements
 
 - Consider exposing a synchronous API for simple use cases in addition to the


### PR DESCRIPTION
## Summary
- note outstanding parity items in `PORT_TODO.md`

## Testing
- `go test ./...`
- `go test -race ./...`


------
https://chatgpt.com/codex/tasks/task_e_68505f7d4f2483279d7e8c76edf10c87